### PR TITLE
Fixed on_ready

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -40,11 +40,13 @@ async def on_message(message):
             await client.send_message(message.channel, msg)
 
 
-@client.event
-async def on_ready():
+async def ready():
+    await client.wait_until_ready()
     print('Logged in as')
     print(client.user.name)
     print(client.user.id)
     print('------')
 
+
+client.loop.create_task(ready())
 client.run(TOKEN)


### PR DESCRIPTION
# Why wait_until_ready over on_ready
Hey there! I noticed you had the `on_ready()` listener implemented. While in this case it probably wouldn't do much harm, doing anything `on_ready()` is generally not good practice, as stated here on the [discord.py documentation page for `on_ready()`](https://discordpy.readthedocs.io/en/latest/api.html?highlight=wait_until_ready#discord.on_ready). Instead, I've implemented `wait_until_ready()`, which is better practice.